### PR TITLE
Fix NullPointerException of configuration-as-code-plugin version 1.10 and later

### DIFF
--- a/docker/container/jenkins-master/jenkins.yaml
+++ b/docker/container/jenkins-master/jenkins.yaml
@@ -22,6 +22,7 @@ jenkins:
       enableCaptcha: false
       users:
       - id: "admin"
+        password: ""
   slaveAgentPort: 50000
   systemMessage: "<h1>Warnings Next Generation Plugin Showcase</h1>"
   nodes:


### PR DESCRIPTION
Version 1.10 of the configuration-as-code-plugin supports encrpyted passwords (https://github.com/jenkinsci/configuration-as-code-plugin/releases/tag/configuration-as-code-1.10)
The check if the password is encrypted needs an not null String (HudsonPrivateSecurityRealmConfigurator.java:57 https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/plugin/src/main/java/io/jenkins/plugins/casc/core/HudsonPrivateSecurityRealmConfigurator.java). 
Maybe it's an issue of the configuration-as-code-plugin, because the password can be null.

This workaround fix the problem by setting an empty String as password.

---------------------------------------------------------------
Thrown Exception while start of jenkins-master_1:

jenkins-master_1  | SEVERE: Failed to initialize Jenkins
jenkins-master_1  | hudson.util.HudsonFailedToLoad: org.jvnet.hudson.reactor.ReactorException: java.lang.Error: java.lang.reflect.InvocationTargetException
jenkins-master_1  | 	at hudson.WebAppMain$3.run(WebAppMain.java:250)
jenkins-master_1  | Caused by: org.jvnet.hudson.reactor.ReactorException: java.lang.Error: java.lang.reflect.InvocationTargetException
jenkins-master_1  | 	at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:282)
jenkins-master_1  | 	at jenkins.InitReactorRunner.run(InitReactorRunner.java:48)
jenkins-master_1  | 	at jenkins.model.Jenkins.executeReactor(Jenkins.java:1130)
jenkins-master_1  | 	at jenkins.model.Jenkins.<init>(Jenkins.java:932)
jenkins-master_1  | 	at hudson.model.Hudson.<init>(Hudson.java:85)
jenkins-master_1  | 	at hudson.model.Hudson.<init>(Hudson.java:81)
jenkins-master_1  | 	at hudson.WebAppMain$3.run(WebAppMain.java:233)
jenkins-master_1  | Caused by: java.lang.Error: java.lang.reflect.InvocationTargetException
jenkins-master_1  | 	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:110)
jenkins-master_1  | 	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:175)
jenkins-master_1  | 	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
jenkins-master_1  | 	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1096)
jenkins-master_1  | 	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
jenkins-master_1  | 	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
jenkins-master_1  | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
jenkins-master_1  | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
jenkins-master_1  | 	at java.lang.Thread.run(Thread.java:748)
jenkins-master_1  | Caused by: java.lang.reflect.InvocationTargetException
jenkins-master_1  | 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
jenkins-master_1  | 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
jenkins-master_1  | 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
jenkins-master_1  | 	at java.lang.reflect.Method.invoke(Method.java:498)
jenkins-master_1  | 	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:104)
jenkins-master_1  | 	... 8 more
jenkins-master_1  | Caused by: io.jenkins.plugins.casc.ConfiguratorException: jenkins: error configuring 'jenkins' with class io.jenkins.plugins.casc.core.JenkinsConfigurator configurator
jenkins-master_1  | 	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:612)
jenkins-master_1  | 	at io.jenkins.plugins.casc.ConfigurationAsCode.checkWith(ConfigurationAsCode.java:644)
jenkins-master_1  | 	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:628)
jenkins-master_1  | 	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:531)
jenkins-master_1  | 	at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:274)
jenkins-master_1  | 	at io.jenkins.plugins.casc.ConfigurationAsCode.init(ConfigurationAsCode.java:266)
jenkins-master_1  | 	... 13 more
jenkins-master_1  | Caused by: io.jenkins.plugins.casc.ConfiguratorException: userWithPassword: Failed to set attribute users(class: class io.jenkins.plugins.casc.core.HudsonPrivateSecurityRealmConfigurator$UserWithPassword, multiple: true)
jenkins-master_1  | 	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:355)
jenkins-master_1  | 	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:271)
jenkins-master_1  | 	at io.jenkins.plugins.casc.impl.configurators.DataBoundConfigurator.configure(DataBoundConfigurator.java:79)
jenkins-master_1  | 	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$doConfigure$16668e2$1(HeteroDescribableConfigurator.java:225)
jenkins-master_1  | 	at io.vavr.CheckedFunction0.lambda$unchecked$52349c75$1(CheckedFunction0.java:201)
jenkins-master_1  | 	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.doConfigure(HeteroDescribableConfigurator.java:225)
jenkins-master_1  | 	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$null$2(HeteroDescribableConfigurator.java:81)
jenkins-master_1  | 	at io.vavr.control.Option.map(Option.java:373)
jenkins-master_1  | 	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.lambda$configure$3(HeteroDescribableConfigurator.java:81)
jenkins-master_1  | 	at io.vavr.Tuple2.apply(Tuple2.java:239)
jenkins-master_1  | 	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.configure(HeteroDescribableConfigurator.java:78)
jenkins-master_1  | 	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.check(HeteroDescribableConfigurator.java:87)
jenkins-master_1  | 	at io.jenkins.plugins.casc.impl.configurators.HeteroDescribableConfigurator.check(HeteroDescribableConfigurator.java:50)
jenkins-master_1  | 	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:347)
jenkins-master_1  | 	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:282)
jenkins-master_1  | 	at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$6(ConfigurationAsCode.java:644)
jenkins-master_1  | 	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:606)
jenkins-master_1  | 	... 18 more
jenkins-master_1  | Caused by: java.lang.NullPointerException
jenkins-master_1  | 	at io.jenkins.plugins.casc.core.HudsonPrivateSecurityRealmConfigurator.setter(HudsonPrivateSecurityRealmConfigurator.java:57)
jenkins-master_1  | 	at io.jenkins.plugins.casc.Attribute.setValue(Attribute.java:169)
jenkins-master_1  | 	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:353)
jenkins-master_1  | 	... 34 more