### PR TITLE
fix for access-rights of authorized_keys file

### DIFF
--- a/docker/container/java-agent/Dockerfile
+++ b/docker/container/java-agent/Dockerfile
@@ -22,7 +22,8 @@ USER agent
 
 RUN mkdir /home/agent/.ssh
 RUN chmod 700 /home/agent/.ssh
-COPY unsafe.pub /home/agent/.ssh/authorized_keys
+COPY --chown=agent:jenkins unsafe.pub /home/agent/.ssh/authorized_keys
+RUN chmod 600 /home/agent/.ssh/authorized_keys
 
 USER root
 COPY docker-entrypoint.sh /


### PR DESCRIPTION
The access-rights of the authorized_keys file in the java-agent node were not set the right way, which prevents the jenkins-master from accessing it via ssh.