### PR TITLE
adapt to new location from Jenkinsfile.analysis in doc/

### DIFF
--- a/docker/images/jenkins-master/jenkins.yaml
+++ b/docker/images/jenkins-master/jenkins.yaml
@@ -191,7 +191,7 @@ jobs:
       pipelineJob('pipeline-warnings-ng') {
           definition {
               cpsScm {
-                  scriptPath 'Jenkinsfile.analysis'
+                  scriptPath 'doc/Jenkinsfile.analysis'
                   scm {
                     git {
                         remote { url 'https://github.com/jenkinsci/warnings-ng-plugin.git' }


### PR DESCRIPTION
The location of the file was changed in commit [b1bf8d8](https://github.com/jenkinsci/warnings-ng-plugin/commit/b1bf8d862e36de68524550f71e89845f6db8ad9d) in the warnings-ng-plugin.

(Rebuilding the docker images is required for this, e.g. via `docker-compose build`.)