### PR TITLE
fix jcasc configuration for email-ext

### DIFF
--- a/docker/images/jenkins-master/jenkins.yaml
+++ b/docker/images/jenkins-master/jenkins.yaml
@@ -96,7 +96,7 @@ credentials:
               username: "agent"
 
 unclassified:
-  extendedEmailPublisher:
+  email-ext:
     adminRequiredForTemplateTesting: false
     allowUnregisteredEnabled: false
     charset: "UTF-8"
@@ -108,8 +108,9 @@ unclassified:
     maxAttachmentSize: -1
     maxAttachmentSizeMb: 0
     precedenceBulk: false
-    useSsl: false
     watchingEnabled: false
+    mailAccount:
+      useSsl: false
   globalDefaultFlowDurabilityLevel:
     durabilityHint: PERFORMANCE_OPTIMIZED
   location:


### PR DESCRIPTION
First run of ./jenkins.sh does not start due to an updated syntax in jcasc:

`io.jenkins.plugins.casc.ConfiguratorException: Invalid configuration elements for type class jenkins.model.GlobalConfigurationCategory$Unclassified : extendedEmailPublisher.
Available attributes : administrativeMonitorsConfiguration, artifactManager, buildDiscarders, casCGlobalConfig, defaultFolderConfiguration, defaultView, email-ext, envVarsFilter, fingerprints, gitHubConfiguration, gitHubPluginConfig, gitSCM, globalConfigFiles, globalDefaultFlowDurabilityLevel, globalLibraries, junitTestResultStorage, location, lockableResourcesManager, mailer, masterBuild, mavenModuleSet, myView, nodeProperties, pipeline-model-docker, pitmutation, plugin, pollSCM, projectNamingStrategy, quietPeriod, resourceRoot, scmRetryCount, shell, timestamper, usageStatistics, viewsTabBar, warningsParsers, warningsPlugin
	at io.jenkins.plugins.casc.BaseConfigurator.handleUnknown(BaseConfigurator.java:376)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:365)
	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:287)
	at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$8(ConfigurationAsCode.java:755)
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:691)
Caused: io.jenkins.plugins.casc.ConfiguratorException: unclassified: error configuring 'unclassified' with class `

Similar issue is discussed here:
https://gitter.im/jenkinsci/configuration-as-code-plugin?at=5f2bd926028fac5e4d9d01b7
