### PR TITLE
Updated Maven version

### DIFF
--- a/docker/images/java11-agent/Dockerfile
+++ b/docker/images/java11-agent/Dockerfile
@@ -12,9 +12,9 @@ RUN apk update \
     && echo "PubkeyAuthentication yes" > /etc/ssh/sshd_config
 USER root
 
-ARG MAVEN_VERSION=3.8.4
+ARG MAVEN_VERSION=3.8.5
 ARG USER_HOME_DIR="/root"
-ARG SHA=a9b2d825eacf2e771ed5d6b0e01398589ac1bfa4171f36154d1b5787879605507802f699da6f7cfc80732a5282fd31b28e4cd6052338cbef0fa1358b48a5e3c8
+ARG SHA=89ab8ece99292476447ef6a6800d9842bbb60787b9b8a45c103aa61d2f205a971d8c3ddfb8b03e514455b4173602bd015e82958c0b3ddc1728a57126f773c743
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN mkdir -p /opt/maven /opt/maven/ref \


### PR DESCRIPTION
I updated the Maven version within the Dockerfile of the java11-agent since the `BASE_URL` did not exist anymore.