### PR TITLE
Update module names in pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,11 @@
   <modules>
 
     <module>analysis-model</module>
-    <module>analysis-model-api</module>
+    <module>analysis-model-api-plugin</module>
 
     <module>coverage-model</module>
 
-    <module>coverage-plugin</module>
+    <module>code-coverage-api-plugin</module>
     <module>warnings-ng-plugin</module>
 
   </modules>


### PR DESCRIPTION
Change module names in pom.xml to match the repo names and corresponding folder names of downloaded repos.
Previously maven was not able to find the modules after downloading the repos with the clone-repos.sh script